### PR TITLE
feat: trigger event upon paying bill

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -19,11 +19,12 @@ function ShowBillsMenu()
 				local billId = element.billId
 
 				ESX.TriggerServerCallback('esx_billing:payBill', function(resp)
-					if resp == true then
-						TriggerEvent("esx_billing:paidBill", billId)
-					end
-
 					ShowBillsMenu()
+
+					if not resp then
+						return
+					end
+					TriggerEvent("esx_billing:paidBill", billId)
 				end, billId)
 			end)
 		else

--- a/client/main.lua
+++ b/client/main.lua
@@ -16,9 +16,15 @@ function ShowBillsMenu()
 			end
 
 			ESX.OpenContext("right", elements, function(menu,element)
-				ESX.TriggerServerCallback('esx_billing:payBill', function()
+				local billId = element.billId
+
+				ESX.TriggerServerCallback('esx_billing:payBill', function(resp)
+					if resp == true then
+						TriggerEvent("esx_billing:paidBill", billId)
+					end
+
 					ShowBillsMenu()
-				end, element.billId)
+				end, billId)
 			end)
 		else
 			ESX.ShowNotification(TranslateCap('no_invoices'))

--- a/server/main.lua
+++ b/server/main.lua
@@ -107,12 +107,13 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 							if rowsChanged == 1 then
 								xPlayer.removeMoney(amount, "Bill Paid")
 								xTarget.addMoney(amount, "Paid bill")
-
+								TriggerEvent("esx_billing:paidBill", source, billId)
 								xPlayer.showNotification(TranslateCap('paid_invoice', ESX.Math.GroupDigits(amount)))
 								xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
+								cb(true)
+							else
+								cb(false)
 							end
-
-							cb()
 						end)
 					elseif xPlayer.getAccount('bank').money >= amount then
 						MySQL.update('DELETE FROM billing WHERE id = ?', {billId},
@@ -120,21 +121,22 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 							if rowsChanged == 1 then
 								xPlayer.removeAccountMoney('bank', amount, "Bill Paid")
 								xTarget.addAccountMoney('bank', amount, "Paid bill")
-
+								TriggerEvent("esx_billing:paidBill", source, billId)
 								xPlayer.showNotification(TranslateCap('paid_invoice', ESX.Math.GroupDigits(amount)))
 								xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
+								cb(true)
+							else
+								cb(false)
 							end
-
-							cb()
 						end)
 					else
 						xTarget.showNotification(TranslateCap('target_no_money'))
 						xPlayer.showNotification(TranslateCap('no_money'))
-						cb()
+						cb(false)
 					end
 				else
 					xPlayer.showNotification(TranslateCap('player_not_online'))
-					cb()
+					cb(false)
 				end
 			else
 				TriggerEvent('esx_addonaccount:getSharedAccount', result.target, function(account)
@@ -144,14 +146,15 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 							if rowsChanged == 1 then
 								xPlayer.removeMoney(amount, "Bill Paid")
 								account.addMoney(amount)
-
+								TriggerEvent("esx_billing:paidBill", source, billId)
 								xPlayer.showNotification(TranslateCap('paid_invoice', ESX.Math.GroupDigits(amount)))
 								if xTarget then
 									xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
 								end
+								cb(true)
+							else
+								cb(false)
 							end
-
-							cb()
 						end)
 					elseif xPlayer.getAccount('bank').money >= amount then
 						MySQL.update('DELETE FROM billing WHERE id = ?', {billId},
@@ -160,13 +163,14 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 								xPlayer.removeAccountMoney('bank', amount, "Bill Paid")
 								account.addMoney(amount)
 								xPlayer.showNotification(TranslateCap('paid_invoice', ESX.Math.GroupDigits(amount)))
-
+								TriggerEvent("esx_billing:paidBill", source, billId)
 								if xTarget then
 									xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
 								end
+								cb(true)
+							else
+								cb(false)
 							end
-
-							cb()
 						end)
 					else
 						if xTarget then
@@ -174,7 +178,7 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 						end
 
 						xPlayer.showNotification(TranslateCap('no_money'))
-						cb()
+						cb(false)
 					end
 				end)
 			end

--- a/server/main.lua
+++ b/server/main.lua
@@ -112,7 +112,7 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 								xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
 								cb(true)
 							else
-								cb(false)
+								cb(nil)
 							end
 						end)
 					elseif xPlayer.getAccount('bank').money >= amount then
@@ -126,17 +126,17 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 								xTarget.showNotification(TranslateCap('received_payment', ESX.Math.GroupDigits(amount)))
 								cb(true)
 							else
-								cb(false)
+								cb(nil)
 							end
 						end)
 					else
 						xTarget.showNotification(TranslateCap('target_no_money'))
 						xPlayer.showNotification(TranslateCap('no_money'))
-						cb(false)
+						cb(nil)
 					end
 				else
 					xPlayer.showNotification(TranslateCap('player_not_online'))
-					cb(false)
+					cb(nil)
 				end
 			else
 				TriggerEvent('esx_addonaccount:getSharedAccount', result.target, function(account)
@@ -153,7 +153,7 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 								end
 								cb(true)
 							else
-								cb(false)
+								cb(nil)
 							end
 						end)
 					elseif xPlayer.getAccount('bank').money >= amount then
@@ -169,7 +169,7 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 								end
 								cb(true)
 							else
-								cb(false)
+								cb(nil)
 							end
 						end)
 					else
@@ -178,7 +178,7 @@ ESX.RegisterServerCallback('esx_billing:payBill', function(source, cb, billId)
 						end
 
 						xPlayer.showNotification(TranslateCap('no_money'))
-						cb(false)
+						cb(nil)
 					end
 				end)
 			end


### PR DESCRIPTION
An event was added to the server & client side to show whether a bill was paid or not.

Why is this neat to have?
Personally I want to add this as it allows other scripts to listen to when esx_billing bills are paid.
Instead of having to periodically fetch the `billing` database table and check the data there.

Forexample: I have a parking enforcement job script, which sends bills via esx_billing, where I'd want to sync the data for whether the bill is paid or not in my script.